### PR TITLE
Add `SECURITY.md` and `CODE_OF_CONDUCT.md`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# CODE OF CONDUCT
+
+The projects hosted in the JupyterLab organizations follow the
+[Project Jupyter Code of Conduct](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # CODE OF CONDUCT
 
-The projects hosted in the JupyterLab organizations follow the
+The projects hosted in the `voila-dashboards` organization follow the
 [Project Jupyter Code of Conduct](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@ Security Policy
 
 ## Reporting a Vulnerability
 
-If you find a security vulnerability in Jupyter, please report it to security@ipython.org.
+If you find a security vulnerability in Voilà, please report it to security@ipython.org.
 
 See more information in our [docs](https://jupyter.org/security).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+Security Policy
+
+## Reporting a Vulnerability
+
+If you find a security vulnerability in Jupyter, please report it to security@ipython.org.
+
+See more information in our [docs](https://jupyter.org/security).


### PR DESCRIPTION
To have the proper links and guidelines displayed on all repos in the `voila-dashboards` organization on GitHub.